### PR TITLE
Fikset en error i `appsettings.json`, som skyldes ugyldig syntaks

### DIFF
--- a/PDSA_System/Server/appsettings.json
+++ b/PDSA_System/Server/appsettings.json
@@ -10,7 +10,7 @@
     "Secret": "VerySecretKey...ChangeMe"
   },
   "ConnectionStrings": {
-    "DefaultConnection": "server=localhost;user=root;database=NordicDoor;port=3306;password=PASSORD" //Endre PASSORD her.
+    "DefaultConnection": "server=localhost;user=root;database=NordicDoor;port=3306;password=PASSORD"
   }
 
 }


### PR DESCRIPTION
En minimal endring i `appsettings.json` med liten/ingen virkning på funksjonalitet, annet enn at error er borte