### PR TITLE
Update README.md

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -28,7 +28,7 @@ Dette vil automatisk laste inn nye endringer når du lagrer filer, noe som gjør
   
 
 ```docker
-docker run --name db -e MYSQL_ROOT_PASSWORD=PASSORD -p 3306:3306 -d docker.io/library/mariadb:latest
+docker run --name db -e TZ=Europe/Oslo -e PGTZ=Europe/Oslo -e MYSQL_ROOT_PASSWORD=PASSORD -p 3306:3306 -d docker.io/library/mariadb:latest
 ```
 
 2. Verifiser at konteineren har status 'Running'

--- a/.github/README.md
+++ b/.github/README.md
@@ -28,7 +28,7 @@ Dette vil automatisk laste inn nye endringer når du lagrer filer, noe som gjør
   
 
 ```docker
-docker run --name db -e TZ=Europe/Oslo -e PGTZ=Europe/Oslo -e MYSQL_ROOT_PASSWORD=PASSORD -p 3306:3306 -d docker.io/library/mariadb:latest
+docker run --name db -e TZ=Europe/Oslo -e MYSQL_ROOT_PASSWORD=PASSORD -p 3306:3306 -d docker.io/library/mariadb:latest
 ```
 
 2. Verifiser at konteineren har status 'Running'


### PR DESCRIPTION
Lagt til parametere som setter riktig tidssone på docker konteineren. Ved å legge de inn med `docker run` så fungerer det også etter man restarter konteineren, i motsetning til hvis man bruker `export ENV TZ="Europe/Oslo"`