### PR TITLE
Auth fix

### DIFF
--- a/PDSA_System/Client/PDSA_System.Client.csproj
+++ b/PDSA_System/Client/PDSA_System.Client.csproj
@@ -25,6 +25,7 @@
 
     <ItemGroup>
         <Folder Include="Models"/>
+        <Folder Include="Pages\Forslag" />
     </ItemGroup>
 
 </Project>

--- a/PDSA_System/Client/PDSA_System.Client.csproj
+++ b/PDSA_System/Client/PDSA_System.Client.csproj
@@ -25,7 +25,7 @@
 
     <ItemGroup>
         <Folder Include="Models"/>
-        <Folder Include="Pages\Forslag" />
+        <Folder Include="Pages\Forslag"/>
     </ItemGroup>
 
 </Project>

--- a/PDSA_System/Server/Controllers/AuthController.cs
+++ b/PDSA_System/Server/Controllers/AuthController.cs
@@ -68,7 +68,7 @@ public class AuthController : ControllerBase
         if (valid)
         {
             JwtClaims claims = new JwtClaims(bruker.Email, bruker.Fornavn, bruker.Etternavn, "Bruker",
-                bruker.AnsattNr.ToString());
+                bruker.AnsattNr.ToString(), _configuration.GetValue<string>("JwtSettings:Secret"));
 
             var token = claims.GenerateToken();
 

--- a/PDSA_System/Server/Controllers/DebugController.cs
+++ b/PDSA_System/Server/Controllers/DebugController.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace PDSA_System.Server.Controllers;
+
+[Route("[controller]")]
+[ApiController]
+public class DebugController : ControllerBase
+{
+    private IConfiguration _configuration;
+
+    public DebugController(IConfiguration configuration)
+    {
+        this._configuration = configuration;
+    }
+
+    // login controller
+    [HttpGet("/debug/tokenRead")]
+    [Authorize]
+    public IActionResult Debug()
+    {
+        //Returnerer tom string dersom `fornavn` ikke er definert. Slipper da feilmelding på grunn av nullverdier
+        var fornavn = HttpContext.User.Identities.First().Claims.FirstOrDefault(claim => claim.Type == "fornavn")?.Value;
+
+        return Ok("Hei, " + fornavn);
+    }
+}

--- a/PDSA_System/Server/Controllers/DebugController.cs
+++ b/PDSA_System/Server/Controllers/DebugController.cs
@@ -20,7 +20,8 @@ public class DebugController : ControllerBase
     public IActionResult Debug()
     {
         //Returnerer tom string dersom `fornavn` ikke er definert. Slipper da feilmelding på grunn av nullverdier
-        var fornavn = HttpContext.User.Identities.First().Claims.FirstOrDefault(claim => claim.Type == "fornavn")?.Value;
+        var fornavn = HttpContext.User.Identities.First().Claims.FirstOrDefault(claim => claim.Type == "fornavn")
+            ?.Value;
 
         return Ok("Hei, " + fornavn);
     }

--- a/PDSA_System/Server/Models/JwtClaims.cs
+++ b/PDSA_System/Server/Models/JwtClaims.cs
@@ -11,18 +11,17 @@ public class JwtClaims
     private string Fornavn { get; set; }
     private string Etternavn { get; set; }
     private string Rolle { get; set; } // Admin, bruker, etc.
-
     private string AnsattNr { get; set; }
-    //private int Exp { get; set; }
+    private string Secret { get; set; }
 
-    public JwtClaims(string epost, string fornavn, string etternavn, string rolle, string ansattNr)
+    public JwtClaims(string epost, string fornavn, string etternavn, string rolle, string ansattNr, string jwtSecret)
     {
         this.Epost = epost;
         this.Fornavn = fornavn;
         this.Etternavn = etternavn;
         this.Rolle = rolle;
         this.AnsattNr = ansattNr;
-        //this.Exp = exp;
+        this.Secret = jwtSecret;
     }
 
     // Generer en JWT token
@@ -40,8 +39,7 @@ public class JwtClaims
         
         // Hente og generere nøkler for autentisering
         // Key er hardcoded kun for utvikling. Denne MÅ endres til å hente fra appsettings.json
-        var key = new SymmetricSecurityKey(
-            Encoding.UTF8.GetBytes("ED02457B5C41D964DBD2F2A609D63FE1BB7528DBE55E1ABF5B52C249CD735797"));
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(Secret ?? "ft2NueB9H8N9p8RpVvWfwWPstApP6gus"));
         var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
         // Generer token, issuer og audience kan vi vente med til senere
@@ -64,7 +62,7 @@ public class JwtClaims
 
         if (tokenS == null)
         {
-            return new JwtClaims("", "", "", "", "");
+            return new JwtClaims("", "", "", "", "", null);
         }
 
         var epost = tokenS.Claims.First(claim => claim.Type == "epost").Value;
@@ -76,6 +74,6 @@ public class JwtClaims
         // Exp er ikke nødvendig å hente ut, da den ikke brukes i applikasjonen, bør implementeres senere
         //var exp = tokenS.Claims.First(claim => claim.Type == "exp").Value;
 
-        return new JwtClaims(epost, fornavn, etternavn, rolle, ansattNr);
+        return new JwtClaims(epost, fornavn, etternavn, rolle, ansattNr, null);
     }
 }

--- a/PDSA_System/Server/Models/JwtClaims.cs
+++ b/PDSA_System/Server/Models/JwtClaims.cs
@@ -30,12 +30,12 @@ public class JwtClaims
     {
         var claims = new[] // Bruker standardiserte navn på claims
         {
-            new Claim(JwtRegisteredClaimNames.GivenName, Fornavn),
-            new Claim(JwtRegisteredClaimNames.FamilyName, Etternavn),
-            new Claim(JwtRegisteredClaimNames.Email, Epost),
+            new Claim("fornavn", Fornavn),
+            new Claim("etternavn", Etternavn),
+            new Claim("epost", Epost),
             new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
-            new Claim("role", Rolle),
-            new Claim("userId", AnsattNr)
+            new Claim("rolle", Rolle),
+            new Claim("brukerId", AnsattNr)
         };
         
         // Hente og generere nøkler for autentisering
@@ -67,11 +67,11 @@ public class JwtClaims
             return new JwtClaims("", "", "", "", "");
         }
 
-        var epost = tokenS.Claims.First(claim => claim.Type == "email").Value;
-        var fornavn = tokenS.Claims.First(claim => claim.Type == "given_name").Value;
-        var etternavn = tokenS.Claims.First(claim => claim.Type == "family_name").Value;
-        var rolle = tokenS.Claims.First(claim => claim.Type == "role").Value;
-        var ansattNr = tokenS.Claims.First(claim => claim.Type == "userId").Value;
+        var epost = tokenS.Claims.First(claim => claim.Type == "epost").Value;
+        var fornavn = tokenS.Claims.First(claim => claim.Type == "fornavn").Value;
+        var etternavn = tokenS.Claims.First(claim => claim.Type == "etternavn").Value;
+        var rolle = tokenS.Claims.First(claim => claim.Type == "rolle").Value;
+        var ansattNr = tokenS.Claims.First(claim => claim.Type == "brukerId").Value;
 
         // Exp er ikke nødvendig å hente ut, da den ikke brukes i applikasjonen, bør implementeres senere
         //var exp = tokenS.Claims.First(claim => claim.Type == "exp").Value;

--- a/PDSA_System/Server/Program.cs
+++ b/PDSA_System/Server/Program.cs
@@ -1,4 +1,7 @@
-﻿using PDSA_System.Server.Models;
+﻿using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using PDSA_System.Server.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -7,6 +10,19 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllersWithViews();
 builder.Services.AddRazorPages();
 builder.Services.AddSwaggerGen();
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer(options =>
+{
+    options.TokenValidationParameters = new TokenValidationParameters()
+    {
+        ValidateAudience = false,
+        ValidateIssuer = false,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["JwtSettings:Secret"] ??"ft2NueB9H8N9p8RpVvWfwWPstApP6gus")),
+        NameClaimType = "userId"
+    };
+});
 
 var app = builder.Build();
 
@@ -30,8 +46,11 @@ app.UseHttpsRedirection();
 app.UseBlazorFrameworkFiles();
 app.UseStaticFiles();
 
+app.UseAuthentication();
+
 app.UseRouting();
 
+app.UseAuthorization();
 
 app.MapRazorPages();
 app.MapControllers();

--- a/PDSA_System/Server/Program.cs
+++ b/PDSA_System/Server/Program.cs
@@ -19,7 +19,9 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJw
         ValidateIssuer = false,
         ValidateLifetime = true,
         ValidateIssuerSigningKey = true,
-        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["JwtSettings:Secret"] ??"ft2NueB9H8N9p8RpVvWfwWPstApP6gus")),
+        IssuerSigningKey =
+            new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["JwtSettings:Secret"] ??
+                                                            "ft2NueB9H8N9p8RpVvWfwWPstApP6gus")),
         NameClaimType = "userId"
     };
 });

--- a/PDSA_System/Server/appsettings.json
+++ b/PDSA_System/Server/appsettings.json
@@ -7,7 +7,7 @@
     },
     "AllowedHosts": "*",
     "JwtSettings": {
-        "Secret": "VerySecretKey...ChangeMe"
+        "Secret": "ft2NueB9H8N9p8RpVvWfwW_CHANGE_ME"
     },
     "ConnectionStrings": {
         "DefaultConnection": "server=localhost;user=root;database=NordicDoor;port=3306;password=PASSORD;"


### PR DESCRIPTION
Autentisering skal funke nå. Headeren `Authorization` må være satt til `Bearer <token>`, der token skal genereres selv fra innlogging.

Kommer med nærmere informasjon angående headers i API-forespørsler i en issue