### PR TITLE
Fikset rolle for JWT

### DIFF
--- a/PDSA_System/Server/Controllers/AuthController.cs
+++ b/PDSA_System/Server/Controllers/AuthController.cs
@@ -59,7 +59,7 @@ public class AuthController : ControllerBase
         // Send token om passordet er riktig
         if (valid)
         {
-            JwtClaims claims = new JwtClaims(bruker.Email, bruker.Fornavn, bruker.Etternavn, "Bruker",
+            JwtClaims claims = new JwtClaims(bruker.Email, bruker.Fornavn, bruker.Etternavn, bruker.Rolle,
                 bruker.AnsattNr.ToString(), _configuration.GetValue<string>("JwtSettings:Secret"));
 
             var token = claims.GenerateToken();


### PR DESCRIPTION
Jeg har helt glemt bort at jeg hardkodet rolle i `AuthController.cs` (pga. debugging). Nå skal det være fikset

Payload fra ny token:
```json
{
  "fornavn": "Magnus",
  "etternavn": "Nymo",
  "epost": "mn@nordic.door",
  "jti": "[REDACTED]",
  "rolle": "teamleder",
  "brukerId": "5",
  "exp": 1667584389
}
```