### PR TITLE
Fjernet duplikate knapper i `NavMenu.razor`, etter en feilet merge

### DIFF
--- a/PDSA_System/Client/Shared/NavMenu.razor
+++ b/PDSA_System/Client/Shared/NavMenu.razor
@@ -19,15 +19,6 @@
 			<NavLink class="nav-link" href="/Login" Match="NavLinkMatch.All">
 				<i class="bi bi-person-circle"></i> Login
 			</NavLink>
-			<NavLink class="nav-link" href="/Forslag" Match="NavLinkMatch.All">
-				<i class="bi bi-list-check"></i> Forslag
-			</NavLink>
-			<NavLink class="nav-link" href="/swagger/index.html" Match="NavLinkMatch.All">
-				<i class="bi bi-braces-asterisk"></i> Swagger
-			</NavLink>
-			<NavLink class="nav-link" href="/Login" Match="NavLinkMatch.All">
-				<i class="bi bi-person-circle"></i> Login
-			</NavLink>
             <NavLink class="nav-link" href="/Forslag" Match="NavLinkMatch.All">
                 <i class="bi bi-list-check"></i> Forslag
             </NavLink>


### PR DESCRIPTION
Klarte på magisk vis å fikse 3 duplikate verdier i navigeringsmeyen
https://github.com/IS-200-G7/nordicdoor/blob/7abf285450655519cb9336c1b17262c738249b37/PDSA_System/Client/Shared/NavMenu.razor#L12-L40